### PR TITLE
Refactor get_data_path function to use a constant for file directory

### DIFF
--- a/model/dataloader.py
+++ b/model/dataloader.py
@@ -1,8 +1,9 @@
 from fastNLP.io import JsonLoader
 from transformers import AutoTokenizer
+from preprocess.preprocess import TOKENIED_FILE_DIR
 
-def get_data_path(PTM, dataset):
-    paths = {'train': f'tokenized_files/{dataset}/train.{PTM}.jsonl', 'val': f'tokenized_files/{dataset}/val.{PTM}.jsonl'}
+def get_data_path(PTM, dataset):   
+    paths = {'train': f'{TOKENIED_FILE_DIR}/{dataset}/train.{PTM}.jsonl', 'val': f'{TOKENIED_FILE_DIR}/{dataset}/val.{PTM}.jsonl'}
     return paths
 
 


### PR DESCRIPTION
This pull request refactors the get_data_path function to use a constant for the file directory instead of hardcoding the path in the function.

The constant `TOKENIZED_FILE_DIR` is imported from `preprocess/preprocess.p`y. This makes the code more modular and easier to maintain, as any changes to the file directory can be made in one place.